### PR TITLE
Bugfix/fix test

### DIFF
--- a/src/main/java/com/pragmatists/blog/events/application/UserQueueNotifier.java
+++ b/src/main/java/com/pragmatists/blog/events/application/UserQueueNotifier.java
@@ -20,10 +20,9 @@ public class UserQueueNotifier {
     }
 
     @EventListener(UserCreated.class)
-//  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) -- uncomment to make pass tests in UserResourceJdbcTemplateTest
-//  @Transactional(propagation = Propagation.REQUIRES_NEW) -- uncomment to make pass method
-//  com.pragmatists.blog.events.application.UserResourceTest#registeredUserHasTokenGenerated and
-//  com.pragmatists.blog.events.application.UserResourceTest#registeredUserHasTokenGenerated
+//    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // uncomment to make pass tests in UserResourceJdbcTemplateTest
+//    @Transactional(propagation = Propagation.REQUIRES_NEW) // uncomment to make pass method
+//    com.pragmatists.blog.events.application.UserResourceTest#registeredUserHasTokenGenerated
     public void onUserCreate(UserCreated userCreated) {
         User user = userRepository.find(userCreated.id);
         user.generateToken();

--- a/src/test/java/com/pragmatists/blog/events/application/UserResourceTest.java
+++ b/src/test/java/com/pragmatists/blog/events/application/UserResourceTest.java
@@ -77,7 +77,7 @@ public void registerPutsEmailAndTokenOnQueue() throws Exception {
         String response = api.get(format("users/%s", userId));
 
         JSONObject jsonObject = new JSONObject(response);
-        assertThat(jsonObject.getString("emailToken")).isNotNull();
+        assertThat(jsonObject.getString("emailToken")).isNotEqualTo("null");
     }
 
     private String givenUserCreated(String login, String email) throws JSONException, IOException {


### PR DESCRIPTION
All tests are passing even if `@Transactional(propagation = Propagation.REQUIRES_NEW)` is not uncommented. The reason is `jsonObject.getString("emailToken")` returns "null" string, not null reference. It's fixed in this PR.